### PR TITLE
add site override commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ For help with Detectify scores: https://blog.detectify.com/2017/05/24/interpret-
 
 ## Commands
 
-`aka detectify:start -a APPNAME -t THRESHOLD`
+`aka detectify:start -a APPNAME -t THRESHOLD -s SITE`
 
-Start a Detectify scan on a given application. The "threshold" option is optional - it allows you to specify the maximum allowable threat score. Otherwise, the default is "6".
+Start a Detectify scan on a given application. 
+
+The "threshold" option is optional - it allows you to specify the maximum allowable threat score. Otherwise, the default is "6".
+
+The "site" option is optional - it acts as a temporary supercharged [site override](#site-overrides) that will override the default endpoint AND any configured site overrides for the app.
 
 `aka detectify:enable -a APPNAME`
 
@@ -32,8 +36,29 @@ Disable Detectify scanning for a given application
 
 Show currently running scans
 
+## Site Overrides
+
+Site overrides allow users to override the endpoint that is scanned for a given app. This is useful in various situations - for example, apps that have configured CSP filters won't allow any traffic on the default app endpoint, so they will need to scan the Akkeris site instead.
+
+Once a site override is set, any subsequent scan of the given app will use the site override URL instead of the default app endpoint.
+
+Please note that only a single site override may be created for an app. Multi-site scans for apps are not currently supported.
+
+### Commands
+
+`aka detectify:sites`
+
+Show all configured site overrides.
+
+`aka detectify:sites:set <SITE> -a APPNAME`
+
+Create a new site override for a given application
+
+`aka detectify:sites:unset -a APPNAME`
+
+Remove the site override for a given application
+
 ## Future Plans
 
-- Ability to run on-demand scans for any app or site
 - Show past scans using the CLI
 - PDF scan results (currently, Detectify does not offer this feature programmatically)

--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ async function start(appkit, args) {
 }
 
 async function enable(appkit, args) {
-  const app = args.app;
+  const { app, site } = args;
+  
   try {
     const hooks = await appkit.api.get(`/apps/${app}/hooks`);
     const needsHook = !hooks.find(hook => hook.url === `${DETECTIFIER_URL}/v1/hook/released`);
@@ -47,6 +48,9 @@ async function enable(appkit, args) {
         events: ['released'],
       };
       await appkit.api.post(JSON.stringify(hook), `/apps/${app}/hooks`);
+      if (site && site !== "") {
+        await appkit.http.post(JSON.stringify({site}), `${DETECTIFIER_URL}/v1/config/${app}`, {'Content-type': 'application/json'});
+      }
       console.log(appkit.terminal.markdown('^^Detectify scanning successfully enabled!^^'));
     } else {
       console.log(appkit.terminal.markdown('!!Detectify scanning is already enabled on this app!!'));
@@ -92,6 +96,45 @@ async function scans(appkit) {
   }
 }
 
+async function listSites(appkit) {
+  try {
+    const config = await appkit.http.get(`${DETECTIFIER_URL}/v1/config`);
+    if (config.length === 0) {
+      console.log(appkit.terminal.markdown('\n!! No configured site overrides. !!'));
+    } else {
+      const formattedConfig = config.map(c => ({
+        "App Name": c.akkeris_app,
+        "Site": c.site,
+      }));
+      console.log(appkit.terminal.markdown('\n^^ Configured Site Overrides ^^'));
+      console.log(appkit.terminal.markdown('### The apps below will run scans on the associated site rather than the default app endpoint.###'))
+      appkit.terminal.table(formattedConfig);
+    }
+  } catch (err) {
+    appkit.terminal.error(err);
+  }
+}
+
+async function setSite(appkit, args) {
+  const { app, site } = args;
+  try {
+    await appkit.http.post(JSON.stringify({site}), `${DETECTIFIER_URL}/v1/config/${app}`, {'Content-type': 'application/json'});
+    console.log(appkit.terminal.markdown(`\n^^✓^^ ~~${site}~~ will now be targeted for any scan on the app ^^${app}^^`))
+  } catch (err) {
+    appkit.terminal.error(err);
+  }
+}
+
+async function removeSite(appkit, args) {
+  const { app } = args;
+  try {
+    await appkit.http.delete(`${DETECTIFIER_URL}/v1/config/${app}`);
+    console.log(appkit.terminal.markdown(`\n^^✓^^ Any scan on the app ^^${app}^^ will now use the default app endpoint.`))
+  } catch (err) {
+    appkit.terminal.error(err);
+  }
+}
+
 function init(appkit) {
   const requireApp = {
     app: {
@@ -110,17 +153,50 @@ function init(appkit) {
       description: 'success threshold',
       demand: false,
     },
+    site: {
+      alias: 's',
+      string: true,
+      description: 'site to scan instead of app endpoint',
+      demand: false,
+    }
   };
+
+  const enableOptions = {
+    ...requireApp,
+    site: {
+      alias: 's',
+      string: true,
+      description: 'add site override that will be scanned instead of app endpoint',
+      demand: false,
+    }
+  }
 
   appkit.args
     .command('detectify:start', 'Start an immediate detectify scan on an app', startOptions, start.bind(null, appkit))
     .command('detectify:run', false, startOptions, start.bind(null,appkit))
 
-    .command('detectify:enable', 'Enable detectify commands on an app', requireApp, enable.bind(null, appkit))
-    .command('detectify:add', false, requireApp, enable.bind(null, appkit))
+    .command('detectify:enable', 'Enable detectify commands on an app', enableOptions, enable.bind(null, appkit))
+    .command('detectify:add', false, enableOptions, enable.bind(null, appkit))
     
     .command('detectify:disable', 'Disable detectify scans on an app', requireApp, disable.bind(null, appkit))
     .command('detectify:remove', false, requireApp, disable.bind(null, appkit))
+
+    .command('detectify:sites', 'View list of configured site overrides', {}, listSites.bind(null, appkit))
+    .command('detectify:overrides', false, {}, listSites.bind(null, appkit))
+
+    .command('detectify:sites:set <SITE>', 'Set a site override for an app', requireApp, setSite.bind(null, appkit))
+    .command('detectify:sites:add <SITE>', false, requireApp, setSite.bind(null, appkit))
+    .command('detectify:overrides:set <SITE>', false, requireApp, setSite.bind(null, appkit))
+    .command('detectify:overrides:add <SITE>', false, requireApp, setSite.bind(null, appkit))
+
+    .command('detectify:sites:unset', 'Remove a site override for an app', requireApp, removeSite.bind(null, appkit))
+    .command('detectify:sites:remove', false, requireApp, removeSite.bind(null, appkit))
+    .command('detectify:sites:destroy', false, requireApp, removeSite.bind(null, appkit))
+    .command('detectify:sites:delete', false, requireApp, removeSite.bind(null, appkit))
+    .command('detectify:overrides:unset', false, requireApp, removeSite.bind(null, appkit))
+    .command('detectify:overrides:remove', false, requireApp, removeSite.bind(null, appkit))
+    .command('detectify:overrides:destroy', false, requireApp, removeSite.bind(null, appkit))
+    .command('detectify:overrides:delete', false, requireApp, removeSite.bind(null, appkit))
     
     .command('detectify:scans', 'Show currently running Detectify scans', {}, scans.bind(null, appkit))
     .command('detectify:running', false, {}, scans.bind(null, appkit))


### PR DESCRIPTION
Add site override commands and associated documentation. This allows users to scan a different endpoint than the default app endpoint (i.e. an akkeris site).